### PR TITLE
Remove get_writer function and initialize writer variable in calling function

### DIFF
--- a/openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb
@@ -135,10 +135,15 @@
    "source": [
     "from torch.utils.tensorboard import SummaryWriter\n",
     "\n",
-    "writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)\n",
+    "writer = None\n",
     "\n",
+    "def get_writer():\n",
+    "    global writer\n",
+    "    if not writer:\n",
+    "        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)\n",
     "\n",
     "def write_metric(node_name, task_name, metric_name, metric, round_number):\n",
+    "    get_writer()\n",
     "    writer.add_scalar(\"{}/{}/{}\".format(node_name, task_name, metric_name),\n",
     "                      metric, round_number)"
    ]

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py
@@ -4,7 +4,18 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
+writer = None
+
+
+def get_writer():
+    """Create global writer object."""
+    global writer
+    if not writer:
+        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    return writer
+
+
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    writer = get_writer()
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py
@@ -3,8 +3,16 @@
 
 from tensorflow.summary import SummaryWriter
 
+writer = None
+
+def get_writer():
+    """Create global writer object."""
+    global writer
+    if not writer:
+        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    return writer
 
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    writer = get_writer()
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/301_torch_cnn_mnist_watermarking/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/301_torch_cnn_mnist_watermarking/src/utils.py
@@ -6,7 +6,18 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
+writer = None
+
+
+def get_writer():
+    """Create global writer object."""
+    global writer
+    if not writer:
+        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    return writer
+
+
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    writer = get_writer()
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/501_pytorch_tinyimagenet_transfer_learning/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/501_pytorch_tinyimagenet_transfer_learning/src/utils.py
@@ -4,7 +4,18 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
+writer = None
+
+
+def get_writer():
+    """Create global writer object."""
+    global writer
+    if not writer:
+        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    return writer
+
+
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
+    writer = get_writer()
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/vertical_fl/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/vertical_fl/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_datastore_cli/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_datastore_cli/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_include_exclude/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_include_exclude/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_internalloop/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_internalloop/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_with_both_options/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_with_both_options/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_without_callable/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_without_callable/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference_with_include_exclude/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference_with_include_exclude/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_subset_of_collaborators/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_subset_of_collaborators/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_validate_particpant_names/src/utils.py
+++ b/tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_validate_particpant_names/src/utils.py
@@ -4,17 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)


### PR DESCRIPTION
Remove the `get_writer` function and initialize the `SummaryWriter` directly in the `write_metric` function in multiple files.

* **openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb**
  - Remove the direct initialization of `SummaryWriter` and replace it with a `get_writer` function.
  - Use the `get_writer` function to initialize the writer in the `write_metric` function.

* **openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py**
  - Remove the direct initialization of `SummaryWriter` and replace it with a `get_writer` function.
  - Use the `get_writer` function to initialize the writer in the `write_metric` function.

* **openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py**
  - Remove the direct initialization of `SummaryWriter` and replace it with a `get_writer` function.
  - Use the `get_writer` function to initialize the writer in the `write_metric` function.

* **openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/301_torch_cnn_mnist_watermarking/src/utils.py**
  - Remove the direct initialization of `SummaryWriter` and replace it with a `get_writer` function.
  - Use the `get_writer` function to initialize the writer in the `write_metric` function.

* **openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/501_pytorch_tinyimagenet_transfer_learning/src/utils.py**
  - Remove the direct initialization of `SummaryWriter` and replace it with a `get_writer` function.
  - Use the `get_writer` function to initialize the writer in the `write_metric` function.

* **openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/vertical_fl/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_datastore_cli/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_include_exclude/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_internalloop/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_with_both_options/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes_initialization_without_callable/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_private_attributes/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference_with_include_exclude/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_reference/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_subset_of_collaborators/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

* **tests/github/experimental/workflow/AggregatorBasedWorkflow/testcase_validate_particpant_names/src/utils.py**
  - Remove the `get_writer` function.
  - Initialize `SummaryWriter` directly in the `write_metric` function.

