### PR TITLE
Remove get_writer function and initialize writer variable in calling function

### DIFF
--- a/openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb
+++ b/openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb
@@ -135,15 +135,8 @@
    "source": [
     "from torch.utils.tensorboard import SummaryWriter\n",
     "\n",
-    "writer = None\n",
-    "\n",
-    "def get_writer():\n",
-    "    global writer\n",
-    "    if not writer:\n",
-    "        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)\n",
-    "\n",
     "def write_metric(node_name, task_name, metric_name, metric, round_number):\n",
-    "    get_writer()\n",
+    "    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)\n",
     "    writer.add_scalar(\"{}/{}/{}\".format(node_name, task_name, metric_name),\n",
     "                      metric, round_number)"
    ]

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py
@@ -4,18 +4,7 @@
 from torch.utils.tensorboard import SummaryWriter
 
 
-writer = None
-
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-    return writer
-
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)

--- a/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py
+++ b/openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py
@@ -3,16 +3,7 @@
 
 from tensorflow.summary import SummaryWriter
 
-writer = None
-
-def get_writer():
-    """Create global writer object."""
-    global writer
-    if not writer:
-        writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
-    return writer
-
 def write_metric(node_name, task_name, metric_name, metric, round_number):
     """Write metric callback."""
-    writer = get_writer()
+    writer = SummaryWriter('./logs/cnn_mnist', flush_secs=5)
     writer.add_scalar(f'{node_name}/{task_name}/{metric_name}', metric, round_number)


### PR DESCRIPTION
Remove the `get_writer` function and initialize the writer variable directly in the calling function.

* Remove the `get_writer` function from `openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/102_aggregator_validation/src/utils.py` and initialize the writer variable directly in the `write_metric` function.
* Remove the `get_writer` function from `openfl-workspace/experimental/workflow/AggregatorBasedWorkflow/104_keras_mnist/src/utils.py` and initialize the writer variable directly in the `write_metric` function.
* Remove the `get_writer` function from `openfl-tutorials/deprecated/native_api/Federated_Pytorch_MNIST_Tutorial.ipynb` and initialize the writer variable directly in the `write_metric` function.

