### PR TITLE
Update tests to pytest format

### DIFF
--- a/tests/end_to_end/test_suites/wf_local_func_tests.py
+++ b/tests/end_to_end/test_suites/wf_local_func_tests.py
@@ -5,12 +5,78 @@ import logging
 
 from tests.end_to_end.utils.common_fixtures import fx_local_federated_workflow
 from tests.end_to_end.workflow.exclude_flow import TestFlowExclude
+from tests.end_to_end.workflow.datastore_cli_flow import TestFlowDatastoreCLI
+from tests.end_to_end.workflow.include_exclude_flow import TestFlowIncludeExclude
+from tests.end_to_end.workflow.include_flow import TestFlowInclude
+from tests.end_to_end.workflow.reference_with_exclude_flow import TestFlowReferenceWithExclude
+from tests.end_to_end.workflow.reference_with_include_flow import TestFlowReferenceWithInclude
+from tests.end_to_end.workflow.reference_flow import TestFlowReference
 
 log = logging.getLogger(__name__)
 
 
 def test_exclude_flow(fx_local_federated_workflow):
     flflow = TestFlowExclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_datastore_cli_flow(fx_local_federated_workflow):
+    flflow = TestFlowDatastoreCLI(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_include_exclude_flow(fx_local_federated_workflow):
+    flflow = TestFlowIncludeExclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_include_flow(fx_local_federated_workflow):
+    flflow = TestFlowInclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_reference_with_exclude_flow(fx_local_federated_workflow):
+    flflow = TestFlowReferenceWithExclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_reference_with_include_flow(fx_local_federated_workflow):
+    flflow = TestFlowReferenceWithInclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e
+
+
+def test_reference_flow(fx_local_federated_workflow):
+    flflow = TestFlowReference(checkpoint=True)
     flflow.runtime = fx_local_federated_workflow.runtime
     try:
         flflow.run()

--- a/tests/end_to_end/test_suites/wf_local_func_tests.py
+++ b/tests/end_to_end/test_suites/wf_local_func_tests.py
@@ -1,0 +1,19 @@
+# Copyright 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import logging
+
+from tests.end_to_end.utils.common_fixtures import fx_local_federated_workflow
+from tests.end_to_end.workflow.exclude_flow import TestFlowExclude
+
+log = logging.getLogger(__name__)
+
+
+def test_exclude_flow(fx_local_federated_workflow):
+    flflow = TestFlowExclude(checkpoint=True)
+    flflow.runtime = fx_local_federated_workflow.runtime
+    try:
+        flflow.run()
+    except Exception as e:
+        log.error(f"Flow failed with exception: {e}")
+        raise e

--- a/tests/end_to_end/utils/common_fixtures.py
+++ b/tests/end_to_end/utils/common_fixtures.py
@@ -5,11 +5,16 @@ import pytest
 import collections
 import concurrent.futures
 import os
+import logging
 
 import tests.end_to_end.utils.docker_helper as dh
 import tests.end_to_end.utils.federation_helper as fh
 from tests.end_to_end.models import aggregator as agg_model, model_owner as mo_model
 
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+
+log = logging.getLogger(__name__)
 
 # Define a named tuple to store the objects for model owner, aggregator, and collaborators
 federation_fixture = collections.namedtuple(
@@ -17,6 +22,10 @@ federation_fixture = collections.namedtuple(
     "model_owner, aggregator, collaborators, workspace_path, local_bind_path",
 )
 
+workflow_local_fixture = collections.namedtuple(
+    "workflow_local_fixture",
+    "aggregator, collaborators, runtime",
+)
 
 @pytest.fixture(scope="function")
 def fx_federation(request):
@@ -112,4 +121,40 @@ def fx_federation(request):
         collaborators=collaborators,
         workspace_path=workspace_path,
         local_bind_path=local_bind_path,
+    )
+
+@pytest.fixture(scope="function")
+def fx_local_federated_workflow(request):
+    """
+    Fixture to set up a local federated workflow for testing.
+    This fixture initializes an `Aggregator` and sets up a list of collaborators
+    based on the number specified in the test configuration. It also configures
+    a `LocalRuntime` with the aggregator, collaborators, and an optional backend
+    if specified in the test configuration.
+    Args:
+        request (FixtureRequest): The pytest request object that provides access
+                                to the test configuration.
+    Yields:
+        LocalRuntime: An instance of `LocalRuntime` configured with the aggregator,
+                    collaborators, and backend.
+    """
+    aggregator = Aggregator()
+
+    # Setup collaborators
+    collaborators_list = []
+    for i in range(request.config.num_collaborators):
+        collaborators_list.append(Collaborator(name=f"collaborator{i}"))
+
+    backend = request.config.backend if hasattr(request.config, 'backend') else None
+    if backend:
+        local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators_list, backend=backend)
+    local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators_list)
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    # Return the federation fixture
+    return workflow_local_fixture(
+        aggregator=aggregator,
+        collaborators=collaborators_list,
+        runtime = local_runtime,
     )

--- a/tests/end_to_end/workflow/datastore_cli_flow.py
+++ b/tests/end_to_end/workflow/datastore_cli_flow.py
@@ -1,0 +1,336 @@
+# Copyright (C) 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+import torch
+import torchvision
+import logging
+
+from copy import deepcopy
+
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+log = logging.getLogger(__name__)
+
+batch_size_train = 64
+learning_rate = 0.01
+momentum = 0.5
+log_interval = 10
+
+random_seed = 1
+torch.backends.cudnn.enabled = False
+torch.manual_seed(random_seed)
+
+mnist_train = torchvision.datasets.MNIST(
+    "files/",
+    train=True,
+    download=True,
+    transform=torchvision.transforms.Compose(
+        [
+            torchvision.transforms.ToTensor(),
+            torchvision.transforms.Normalize((0.1307,), (0.3081,)),
+        ]
+    ),
+)
+
+mnist_test = torchvision.datasets.MNIST(
+    "files/",
+    train=False,
+    download=True,
+    transform=torchvision.transforms.Compose(
+        [
+            torchvision.transforms.ToTensor(),
+            torchvision.transforms.Normalize((0.1307,), (0.3081,)),
+        ]
+    ),
+)
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.fc1 = nn.Linear(1440, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = x.view(-1, 1440)
+        x = F.relu(self.fc1(x))
+        return F.log_softmax(x)
+
+
+def inference(network, test_loader):
+    network.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            output = network(data)
+            test_loss += F.nll_loss(output, target, size_average=False).item()
+            pred = output.data.max(1, keepdim=True)[1]
+            correct += pred.eq(target.data.view_as(pred)).sum()
+    test_loss /= len(test_loader.dataset)
+    accuracy = float(correct / len(test_loader.dataset))
+    return accuracy
+
+
+class TestFlowDatastoreAndCli(FLSpec):
+    """
+    Testflow for Dataflow and CLI Functionality
+    """
+    def __init__(self, model=None, optimizer=None, rounds=3, **kwargs):
+        super().__init__(**kwargs)
+        if model is not None:
+            self.model = model
+            self.optimizer = optimizer
+        else:
+            self.model = Net()
+            self.optimizer = optim.SGD(
+                self.model.parameters(), lr=learning_rate, momentum=momentum
+            )
+        self.num_rounds = rounds
+        self.current_round = 0
+
+    @aggregator
+    def start(self):
+        log.info("Testing FederatedFlow - Starting Test for Dataflow and CLI Functionality")
+        self.collaborators = self.runtime.collaborators
+        self.private = 10
+        self.next(
+            self.aggregated_model_validation,
+            foreach="collaborators",
+            exclude=["private"],
+        )
+
+    @collaborator
+    def aggregated_model_validation(self):
+        log.info("Performing aggregated model validation for collaborator")
+        self.agg_validation_score = inference(self.model, self.test_loader)
+        self.next(self.train)
+
+    @collaborator
+    def train(self):
+        log.info("Train the model")
+        self.model.train()
+        self.optimizer = optim.SGD(
+            self.model.parameters(), lr=learning_rate, momentum=momentum
+        )
+        for batch_idx, (data, target) in enumerate(self.train_loader):
+            self.optimizer.zero_grad()
+            output = self.model(data)
+            loss = F.nll_loss(output, target)
+            loss.backward()
+            self.optimizer.step()
+            if batch_idx % log_interval == 0:
+                self.loss = loss.item()
+                torch.save(self.model.state_dict(), "model.pth")
+                torch.save(self.optimizer.state_dict(), "optimizer.pth")
+        self.training_completed = True
+        self.next(self.local_model_validation)
+
+    @collaborator
+    def local_model_validation(self):
+        self.local_validation_score = inference(self.model, self.test_loader)
+        log.info("Doing local model validation for collaborator")
+        self.next(self.join, exclude=["training_completed"])
+
+    @aggregator
+    def join(self, inputs):
+        log.info("Executing join")
+        self.current_round += 1
+        if self.current_round < self.num_rounds:
+            self.next(self.start)
+        else:
+            self.next(self.end)
+
+    @aggregator
+    def end(self):
+        log.info("This is the end of the flow")
+
+
+def validate_datastore_cli(flow_obj, expected_flow_steps, num_rounds):
+    """
+    This function test the flow as below
+    1. Verify datastore steps and expected steps are matching
+    2. Verify task stdout and task stderr verified through \
+        cli is as expected
+    3. Verify no of tasks executed is aligned with the total \
+        number of rounds and total number of collaborators
+    """
+    validate_flow_error = []
+
+    verify_stdout = {
+        "start":
+            "\x1b[94mTesting FederatedFlow - Starting Test for Dataflow"
+            + " and CLI Functionality\x1b[0m\x1b[94m\n\x1b[0m\n",
+        "aggregated_model_validation":
+            "\x1b[94mPerforming aggregated model validation for"
+            + " collaborator\x1b[0m\x1b[94m\n\x1b[0m\n",
+        "train": "\x1b[94mTrain the model\x1b[0m\x1b[94m\n\x1b[0m\n",
+        "local_model_validation":
+            "\x1b[94mDoing local model validation for collaborator"
+            + "\x1b[0m\x1b[94m\n\x1b[0m\n",
+        "join": "\x1b[94mExecuting join\x1b[0m\x1b[94m\n\x1b[0m\n",
+        "end": "\x1b[94mThis is the end of the flow\x1b[0m\x1b[94m\n\x1b[0m\n",
+    }
+
+    # fetch data from metaflow
+    from metaflow import Flow
+
+    cli_flow_obj = Flow("TestFlowDatastoreAndCli")
+    cli_flow_steps = list(list(cli_flow_obj)[0])
+    cli_step_names = [step.id for step in cli_flow_steps]
+
+    steps_present_in_cli = [
+        step for step in expected_flow_steps if step in cli_step_names
+    ]
+    missing_steps_in_cli = [
+        step for step in expected_flow_steps if step not in cli_step_names
+    ]
+    extra_steps_in_cli = [
+        step for step in cli_step_names if step not in expected_flow_steps
+    ]
+
+    if len(steps_present_in_cli) != len(expected_flow_steps):
+        validate_flow_error.append(
+            f"... Error : Number of steps fetched from \
+                Datastore through CLI do not match the Expected steps provided  \n"
+        )
+
+    if len(missing_steps_in_cli) != 0:
+        validate_flow_error.append(
+            f"... Error : Following steps missing from Datastore: \
+                {missing_steps_in_cli}  \n"
+        )
+
+    if len(extra_steps_in_cli) != 0:
+        validate_flow_error.append(
+            f"... Error : Following steps are extra in Datastore: \
+                {extra_steps_in_cli}  \n"
+        )
+
+    for step in cli_flow_steps:
+        task_count = 0
+        func = getattr(flow_obj, step.id)
+        for task in list(step):
+            task_count = task_count + 1
+            if verify_stdout.get(step.id) != task.stdout:
+                validate_flow_error.append(
+                    f"... Error : task stdout detected issues : \
+                        {step} {task} \n"
+                )
+
+        if (
+            (func.aggregator_step)
+            and (task_count != num_rounds)
+            and (func.__name__ != "end")
+        ):
+            validate_flow_error.append(
+                f"... Error : More than one execution detected \
+                    for Aggregator Step: {step}  \n"
+            )
+
+        if (
+            (func.aggregator_step)
+            and (task_count != 1)
+            and (func.__name__ == "end")
+        ):
+            validate_flow_error.append(
+                f"... Error : More than one execution detected \
+                    for Aggregator Step: {step}  \n"
+            )
+
+        if (func.collaborator_step) and (
+            task_count != len(flow_obj.collaborators) * num_rounds
+        ):
+            validate_flow_error.append(
+                f"... Error : Incorrect number of execution \
+                    detected for Collaborator Step: {step}. \
+                        Expected: {num_rounds*len(flow_obj.collaborators)} \
+                        Actual: {task_count} \n"
+            )
+
+    if validate_flow_error:
+        display_validate_errors(validate_flow_error)
+    else:
+        log.info(f"""\n**** Summary of internal flow testing ****
+              No issues found and below are the tests that ran successfully
+              1. Datastore steps and expected steps are matching
+              2. Task stdout and task stderr verified through metaflow cli is as expected
+              3. Number of tasks are aligned with number of rounds and number\
+                  of collaborators """)
+
+
+def display_validate_errors(validate_flow_error):
+    """
+    Function to display error that is captured during datastore and cli test
+    """
+    log.info(
+        f"Testing FederatedFlow - Ending test for validatng \
+        the Datastore and Cli Testing "
+    )
+    log.error("".join(validate_flow_error))
+    log.error("\n ... Test case failed ...  ")
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator_ = Aggregator()
+
+    collaborator_names = ["Portland", "Seattle", "Chandler", "Bangalore"]
+
+    def callable_to_initialize_collaborator_private_attributes(
+        n_collaborators, index, train_dataset, test_dataset, batch_size
+    ):
+        local_train = deepcopy(train_dataset)
+        local_test = deepcopy(test_dataset)
+        local_train.data = mnist_train.data[index::n_collaborators]
+        local_train.targets = mnist_train.targets[index::n_collaborators]
+        local_test.data = mnist_test.data[index::n_collaborators]
+        local_test.targets = mnist_test.targets[index::n_collaborators]
+        return {
+            "train_loader": torch.utils.data.DataLoader(
+                local_train, batch_size=batch_size, shuffle=True
+            ),
+            "test_loader": torch.utils.data.DataLoader(
+                local_test, batch_size=batch_size, shuffle=True
+            ),
+        }
+
+    collaborators = []
+    for idx, collaborator_name in enumerate(collaborator_names):
+        collaborators.append(
+            Collaborator(
+                name=collaborator_name, num_cpus=0, num_gpus=0.0,
+                private_attributes_callable=callable_to_initialize_collaborator_private_attributes,
+                n_collaborators=len(collaborator_names), index=idx, train_dataset=mnist_train,
+                test_dataset=mnist_test, batch_size=32
+            )
+        )
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator_, collaborators=collaborators, backend="ray"
+    )
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+    num_rounds = 5
+    model = None
+    optimizer = None
+    flflow = TestFlowDatastoreAndCli(model, optimizer, num_rounds, checkpoint=True)
+    flflow.runtime = local_runtime
+    flflow.run()
+
+    expected_flow_steps = [
+        "start",
+        "aggregated_model_validation",
+        "train",
+        "local_model_validation",
+        "join",
+        "end",
+    ]  # List to verify expected steps
+    validate_datastore_cli(
+        flflow, expected_flow_steps, num_rounds
+    )  # Function to validate datastore and cli

--- a/tests/end_to_end/workflow/exclude_flow.py
+++ b/tests/end_to_end/workflow/exclude_flow.py
@@ -1,0 +1,132 @@
+import logging
+
+from openfl.experimental.workflow.interface import FLSpec
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+log = logging.getLogger(__name__)
+
+class TestFlowExclude(FLSpec):
+    """
+    Testflow to validate exclude functionality in Federated Flow
+    """
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+        """
+        log.info("Testing WorkFlow - Starting Test for Exclude Attributes")
+        self.collaborators = self.runtime.collaborators
+
+        self.exclude_agg_to_agg = 10
+        self.include_agg_to_agg = 100
+        self.next(self.test_exclude_agg_to_agg, exclude=["exclude_agg_to_agg"])
+
+    @aggregator
+    def test_exclude_agg_to_agg(self):
+        """
+        Testing whether attributes are excluded from agg to agg
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        ):
+            log.info("... Exclude test passed in test_exclude_agg_to_agg")
+        else:
+            log.error("... Exclude test failed in test_exclude_agg_to_agg")
+            raise ValueError("test_exclude_agg_to_agg")
+
+        self.exclude_agg_to_collab = 20
+        self.include_agg_to_collab = 100
+        self.next(
+            self.test_exclude_agg_to_collab,
+            foreach="collaborators",
+            exclude=["exclude_agg_to_collab"],
+        )
+
+    @collaborator
+    def test_exclude_agg_to_collab(self):
+        """
+        Testing whether attributes are excluded from agg to collab
+        """
+
+        if (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+        ):
+            log.info("... Exclude test passed in test_exclude_agg_to_collab")
+        else:
+            log.error("... Exclude test failed in test_exclude_agg_to_collab")
+            raise ValueError("test_exclude_agg_to_collab")
+
+        self.exclude_collab_to_collab = 10
+        self.include_collab_to_collab = 44
+        self.next(
+            self.test_exclude_collab_to_collab,
+            exclude=["exclude_collab_to_collab"],
+        )
+
+    @collaborator
+    def test_exclude_collab_to_collab(self):
+        """
+        Testing whether attributes are excluded from collab to collab
+        """
+
+        if (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "include_collab_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+            and hasattr(self, "exclude_collab_to_collab") is False
+        ):
+            log.info("... Exclude test passed in test_exclude_collab_to_collab")
+        else:
+            log.error("... Exclude test failed in test_exclude_collab_to_collab")
+            raise ValueError("test_exclude_collab_to_collab")
+
+        self.exclude_collab_to_agg = 20
+        self.include_collab_to_agg = 56
+        self.next(self.join, exclude=["exclude_collab_to_agg"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Testing whether attributes are excluded from collab to agg
+        """
+        # Aggregator attribute check
+        validate = (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        )
+
+        # Collaborator attribute check
+        for input in inputs:
+            validation = validate and (
+                hasattr(input, "include_collab_to_collab") is True
+                and hasattr(input, "exclude_collab_to_collab") is False
+                and hasattr(input, "exclude_collab_to_agg") is False
+                and hasattr(input, "include_collab_to_agg") is True
+            )
+
+        if validation:
+            log.info("... Exclude test passed in join")
+        else:
+            log.error("... Exclude test failed in join")
+            raise ValueError("join")
+
+        log.info("Exclude attribute test summary:")
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+
+        """
+        log.info("Testing FederatedFlow - Ending Test for Exclude Attributes")

--- a/tests/end_to_end/workflow/include_exclude_flow.py
+++ b/tests/end_to_end/workflow/include_exclude_flow.py
@@ -1,0 +1,182 @@
+# Copyright (C) 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+log = logging.getLogger(__name__)
+
+class TestFlowIncludeExclude(FLSpec):
+    """
+    Testflow to validate include and exclude functionality in Federated Flow.
+    """
+
+    include_exclude_error_list = []
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+        """
+        log.info("Testing FederatedFlow - Starting Test for Include and Exclude Attributes")
+        self.collaborators = self.runtime.collaborators
+
+        self.exclude_agg_to_agg = 10
+        self.include_agg_to_agg = 100
+        self.next(self.test_include_exclude_agg_to_agg, exclude=["exclude_agg_to_agg"])
+
+    @aggregator
+    def test_include_exclude_agg_to_agg(self):
+        """
+        Testing whether attributes are excluded from agg to agg
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        ):
+            log.info("... Exclude test passed in test_include_exclude_agg_to_agg")
+        else:
+            TestFlowIncludeExclude.include_exclude_error_list.append(
+                "test_include_exclude_agg_to_agg"
+            )
+            log.error("... Exclude test failed in test_incude_exclude_agg_to_agg")
+
+        self.include_agg_to_collab = 100
+        self.exclude_agg_to_collab = 78
+        self.next(
+            self.test_include_exclude_agg_to_collab,
+            foreach="collaborators",
+            include=["include_agg_to_collab", "collaborators"],
+        )
+
+    @collaborator
+    def test_include_exclude_agg_to_collab(self):
+        """
+        Testing whether attributes are included from agg to collab
+        """
+
+        if (
+            hasattr(self, "include_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+            and hasattr(self, "include_agg_to_collab") is True
+        ):
+            log.info("... Include test passed in test_include_exclude_agg_to_collab")
+        else:
+            TestFlowIncludeExclude.include_exclude_error_list.append(
+                "test_incude_exclude_agg_to_collab"
+            )
+            log.error("... Include test failed in test_include_exclude_agg_to_collab")
+        self.exclude_collab_to_collab = 10
+        self.include_collab_to_collab = 44
+        self.next(
+            self.test_include_exclude_collab_to_collab,
+            exclude=["exclude_collab_to_collab"],
+        )
+
+    @collaborator
+    def test_include_exclude_collab_to_collab(self):
+        """
+        Testing whether attributes are excluded from collab to collab
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is False
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "include_collab_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+            and hasattr(self, "exclude_collab_to_collab") is False
+        ):
+            log.info("... Exclude test passed in test_include_exclude_collab_to_collab")
+        else:
+            TestFlowIncludeExclude.include_exclude_error_list.append(
+                "test_incude_exclude_collab_to_collab"
+            )
+            log.error("... Exclude test failed in test_include_exclude_collab_to_collab")
+
+        self.exclude_collab_to_agg = 20
+        self.include_collab_to_agg = 56
+        self.next(self.join, include=["include_collab_to_agg"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Testing whether attributes are included from collab to agg
+        """
+        # Aggregator attribute check
+        validate = (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        )
+
+        # Collaborator attribute check
+        for input in inputs:
+            validation = validate and (
+                hasattr(input, "include_collab_to_collab") is False
+                and hasattr(input, "exclude_collab_to_collab") is False
+                and hasattr(input, "exclude_collab_to_agg") is False
+                and hasattr(input, "include_collab_to_agg") is True
+            )
+
+        if validation:
+            log.info("... Include and Exclude tests passed in join")
+        else:
+            TestFlowIncludeExclude.include_exclude_error_list.append("join")
+            log.error("... Include and Exclude tests failed in join")
+
+        log.info("Include and exclude attributes test summary:")
+
+        if TestFlowIncludeExclude.include_exclude_error_list:
+            validated_include_exclude_variables = ",".join(
+                TestFlowIncludeExclude.include_exclude_error_list
+            )
+            log.error(f"...Test case failed for {validated_include_exclude_variables}")
+
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+        """
+        log.info("Testing FederatedFlow - Ending Test for Include and Exclude Attributes")
+        if TestFlowIncludeExclude.include_exclude_error_list:
+            raise (
+                AssertionError(
+                    "\n ...Test case failed ..."
+                )
+            )
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator = Aggregator()
+
+    # Setup collaborators
+    collaborator_names = ["Portland", "Chandler", "Bangalore", "Delhi"]
+    collaborators = []
+    for collaborator_name in collaborator_names:
+        collaborators.append(
+            Collaborator(
+                name=collaborator_name,
+            )
+        )
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator,
+        collaborators=collaborators,
+    )
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+    flflow = TestFlowIncludeExclude(checkpoint=True)
+    flflow.runtime = local_runtime
+    for i in range(5):
+        log.info(f"Starting round {i}...")
+        flflow.run()
+
+    log.info("End of Testing FederatedFlow")

--- a/tests/end_to_end/workflow/include_flow.py
+++ b/tests/end_to_end/workflow/include_flow.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import logging
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+log = logging.getLogger(__name__)
+
+class TestFlowInclude(FLSpec):
+    """
+    Testflow to validate include functionality in Federated Flow
+    """
+
+    include_error_list = []
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+        """
+        log.info("Testing FederatedFlow - Starting Test for Include Attributes")
+        self.collaborators = self.runtime.collaborators
+
+        self.exclude_agg_to_agg = 10
+        self.include_agg_to_agg = 100
+        self.next(
+            self.test_include_agg_to_agg,
+            include=["include_agg_to_agg", "collaborators"],
+        )
+
+    @aggregator
+    def test_include_agg_to_agg(self):
+        """
+        Testing whether attributes are included from agg to agg
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        ):
+            log.info("... Include test passed in test_include_agg_to_agg")
+        else:
+            TestFlowInclude.include_error_list.append("test_include_agg_to_agg")
+            log.error("... Include test failed in test_include_agg_to_agg")
+
+        self.include_agg_to_collab = 100
+        self.exclude_agg_to_collab = 78
+        self.next(
+            self.test_include_agg_to_collab,
+            foreach="collaborators",
+            include=["include_agg_to_collab", "collaborators"],
+        )
+
+    @collaborator
+    def test_include_agg_to_collab(self):
+        """
+        Testing whether attributes are included from agg to collab
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+            and hasattr(self, "include_agg_to_collab") is True
+        ):
+            log.info("... Include test passed in test_include_agg_to_collab")
+        else:
+            TestFlowInclude.include_error_list.append("test_include_agg_to_collab")
+            log.error("... Include test failed in test_include_agg_to_collab")
+        self.exclude_collab_to_collab = 10
+        self.include_collab_to_collab = 44
+        self.next(
+            self.test_include_collab_to_collab,
+            include=["include_collab_to_collab"],
+        )
+
+    @collaborator
+    def test_include_collab_to_collab(self):
+        """
+        Testing whether attributes are included from collab to collab
+        """
+        if (
+            hasattr(self, "include_agg_to_agg") is False
+            and hasattr(self, "include_agg_to_collab") is False
+            and hasattr(self, "include_collab_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+            and hasattr(self, "exclude_agg_to_collab") is False
+            and hasattr(self, "exclude_collab_to_collab") is False
+        ):
+            log.info("... Include test passed in test_include_collab_to_collab")
+        else:
+            TestFlowInclude.include_error_list.append("test_include_collab_to_collab")
+            log.error("... Include test failed in test_include_collab_to_collab")
+
+        self.exclude_collab_to_agg = 20
+        self.include_collab_to_agg = 56
+        self.next(self.join, include=["include_collab_to_agg"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Testing whether attributes are included from collab to agg
+        """
+        # Aggregator attribute check
+        validate = (
+            hasattr(self, "include_agg_to_agg") is True
+            and hasattr(self, "include_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_collab") is True
+            and hasattr(self, "exclude_agg_to_agg") is False
+        )
+
+        # Collaborator attribute check
+        for input in inputs:
+            validation = validate and (
+                hasattr(input, "include_collab_to_collab") is False
+                and hasattr(input, "exclude_collab_to_collab") is False
+                and hasattr(input, "exclude_collab_to_agg") is False
+                and hasattr(input, "include_collab_to_agg") is True
+            )
+
+        if validation:
+            log.info("... Include test passed in join")
+        else:
+            TestFlowInclude.include_error_list.append("join")
+            log.error("... Include test failed in join")
+
+        log.info("Include attribute test summary:")
+
+        if TestFlowInclude.include_error_list:
+            validated_include_variables = ",".join(TestFlowInclude.include_error_list)
+            log.error(f"...Test case failed for {validated_include_variables}")
+
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+        """
+        log.info("Testing FederatedFlow - Ending Test for Include Attributes")
+        if TestFlowInclude.include_error_list:
+            raise (
+                AssertionError(
+                    "\n ...Test case failed ..."
+                )
+            )
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator = Aggregator()
+
+    # Setup collaborators
+    collaborator_names = ["Portland", "Chandler", "Bangalore", "Delhi"]
+    collaborators = []
+    for collaborator_name in collaborator_names:
+        collaborators.append(Collaborator(name=collaborator_name))
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator,
+        collaborators=collaborators,
+    )
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "ray":
+            local_runtime = LocalRuntime(
+                aggregator=aggregator, collaborators=collaborators, backend="ray"
+            )
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    flflow = TestFlowInclude(checkpoint=True)
+    flflow.runtime = local_runtime
+    for i in range(5):
+        log.info(f"Starting round {i}...")
+        flflow.run()
+
+    log.info("End of Testing FederatedFlow")

--- a/tests/end_to_end/workflow/reference_flow.py
+++ b/tests/end_to_end/workflow/reference_flow.py
@@ -1,0 +1,350 @@
+# Copyright (C) 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+import sys
+import io
+import math
+import logging
+import torch.nn as nn
+import torch.optim as optim
+import inspect
+from types import MethodType
+
+log = logging.getLogger(__name__)
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.linear1 = nn.Linear(60, 100)
+        self.linear2 = nn.Linear(100, 10)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.linear2(x)
+        return x
+
+
+class TestFlowReference(FLSpec):
+
+    """
+    Testflow to validate references of collabartor attributes in Federated Flow.
+
+    """
+
+    step_one_collab_attrs = []
+    step_two_collab_attrs = []
+    all_ref_error_dict = {}
+    agg_attr_dict = {}
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+
+        """
+        log.info("Testing FederatedFlow - Starting Test for validating references.")
+        self.next(self.test_create_agg_attr)
+
+    @aggregator
+    def test_create_agg_attr(self):
+        """
+        Create different types of objects.
+        """
+
+        self.agg_attr_int = 10
+        self.agg_attr_str = "Test string data"
+        self.agg_attr_list = [1, 2, 5, 6, 7, 8]
+        self.agg_attr_dict = {key: key for key in range(5)}
+        self.agg_attr_file = io.StringIO("Test file data in aggregator")
+        self.agg_attr_math = math.sqrt(2)
+        self.agg_attr_complex_num = complex(2, 3)
+        self.agg_attr_log = logging.getLogger("Test logger data in aggregator")
+        self.agg_attr_model = Net()
+        self.agg_attr_optimizer = optim.SGD(
+            self.agg_attr_model.parameters(), lr=1e-3, momentum=1e-2
+        )
+        self.collaborators = self.runtime.collaborators
+
+        # get aggregator attributes
+        agg_attr_list = filter_attrs(inspect.getmembers(self))
+        for attr in agg_attr_list:
+            agg_attr_id = id(getattr(self, attr))
+            TestFlowReference.agg_attr_dict[attr] = agg_attr_id
+        self.next(self.test_create_collab_attr, foreach="collaborators")
+
+    @collaborator
+    def test_create_collab_attr(self):
+        """
+        Modify the attirbutes of aggregator to validate the references.
+        Create different types of objects.
+        """
+
+        self.agg_attr_int += self.index
+        self.agg_attr_str = self.agg_attr_str + " " + self.input
+        self.agg_attr_complex_num += complex(self.index, self.index)
+        self.agg_attr_math += self.index
+        self.agg_attr_log = " " + self.input
+
+        self.collab_attr_int_one = 20 + self.index
+        self.collab_attr_str_one = "Test string data in collab " + self.input
+        self.collab_attr_list_one = [1, 2, 5, 6, 7, 8]
+        self.collab_attr_dict_one = {key: key for key in range(5)}
+        self.collab_attr_file_one = io.StringIO("Test file data in collaborator")
+        self.collab_attr_math_one = math.sqrt(self.index)
+        self.collab_attr_complex_num_one = complex(self.index, self.index)
+        self.collab_attr_log_one = logging.getLogger(
+            "Test logger data in collaborator " + self.input
+        )
+
+        # append attributes of collaborator
+        TestFlowReference.step_one_collab_attrs.append(self)
+
+        if len(TestFlowReference.step_one_collab_attrs) >= 2:
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list, TestFlowReference.step_one_collab_attrs
+            )
+            validate_collab_references(matched_ref_dict)
+
+        self.next(self.test_create_more_collab_attr)
+
+    @collaborator
+    def test_create_more_collab_attr(self):
+        """
+        Create different types of objects.
+        """
+
+        self.collab_attr_int_two = 30 + self.index
+        self.collab_attr_str_two = "String reference three " + self.input
+        self.collab_attr_list_two = [1, 2, 3, 5, 6, 8]
+        self.collab_attr_dict_two = {key: key for key in range(5)}
+        self.collab_attr_file_two = io.StringIO("Test file reference one")
+        self.collab_attr_math_two = math.sqrt(2)
+        self.collab_attr_complex_num_two = complex(2, 3)
+        self.collab_attr_log_two = logging.getLogger(
+            "Test logger data in collaborator" + self.input
+        )
+
+        TestFlowReference.step_two_collab_attrs.append(self)
+
+        if len(TestFlowReference.step_two_collab_attrs) >= 2:
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list, TestFlowReference.step_two_collab_attrs
+            )
+            validate_collab_references(matched_ref_dict)
+
+        self.next(self.join)
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Iterate over the references of collaborator attributes
+        validate uniqueness of attributes and raise assertion
+        """
+
+        all_attr_list = filter_attrs(inspect.getmembers(inputs[0]))
+        agg_attrs = filter_attrs(inspect.getmembers(self))
+
+        # validate aggregator references are intact after coming out of collaborators.
+        validate_agg_attr_ref(agg_attrs, self)
+
+        # validate collaborators references are not shared in between.
+        matched_ref_dict = find_matched_references(all_attr_list, inputs)
+        validate_collab_references(matched_ref_dict)
+
+        # validate aggregator references are not shared with any of the collaborators .
+        validate_agg_collab_references(inputs, self, agg_attrs)
+
+        all_shared_attr = ""
+        log.info(f"Reference test summary:")
+        for val in TestFlowReference.all_ref_error_dict.values():
+            all_shared_attr = all_shared_attr + ",".join(val)
+        if all_shared_attr:
+            log.error(f"...Test case failed for {all_shared_attr}")
+        else:
+            log.info(f"...Test case passed for all the attributes.")
+
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+
+        """
+        log.info("Testing FederatedFlow - Ending test for validatng the references.")
+        if TestFlowReference.all_ref_error_dict:
+            raise (
+                AssertionError(
+                    "\n ...Test case failed ..."
+                )
+            )
+
+        TestFlowReference.step_one_collab_attrs = []
+        TestFlowReference.step_two_collab_attrs = []
+        TestFlowReference.all_ref_error_dict = {}
+
+
+def filter_attrs(attr_list):
+    valid_attrs = []
+    reserved_words = ["next", "runtime", "execute_next"]
+    for attr in attr_list:
+        if (
+            not attr[0].startswith("_")
+            and attr[0] not in reserved_words
+            and not hasattr(TestFlowReference, attr[0])
+        ):
+            if not isinstance(attr[1], MethodType):
+                valid_attrs.append(attr[0])
+    return valid_attrs
+
+
+def find_matched_references(collab_attr_list, all_collaborators):
+    """
+    Iterate attributes of collborator and capture the duplicate reference
+    return: dict: {
+                    'Portland': ['failed attributes'], 'Seattle': [],
+                  }
+    """
+    matched_ref_dict = {}
+    for i in range(len(all_collaborators)):
+        matched_ref_dict[all_collaborators[i].input] = []
+
+    # For each attribute in the collaborator attribute list, check if any of the collaborator
+    # attributes are shared with another collaborator
+    for attr_name in collab_attr_list:
+        for i, curr_collab in enumerate(all_collaborators):
+            # Compare the current collaborator with the collaborator(s) that come(s) after it.
+            for next_collab in all_collaborators[i + 1:]:
+                # Check if both collaborators have the current attribute
+                if hasattr(curr_collab, attr_name) and hasattr(next_collab, attr_name):
+                    # Check if both collaborators are sharing same reference
+                    if getattr(curr_collab, attr_name) is getattr(
+                        next_collab, attr_name
+                    ):
+                        matched_ref_dict[curr_collab.input].append(attr_name)
+                        log.error(
+                            f"... Reference test failed - {curr_collab.input} \
+                                sharing same "
+                            + f"{attr_name} reference with {next_collab.input}"
+                        )
+
+    return matched_ref_dict
+
+
+def validate_collab_references(matched_ref_dict):
+    """
+    Iterate reference list and raise assertion for conflicts
+    """
+    collborators_sharing_ref = []
+    reference_flag = False
+
+    for collab, val in matched_ref_dict.items():
+        if val:
+            collborators_sharing_ref.append(collab)
+            reference_flag = True
+    if collborators_sharing_ref:
+        for collab in collborators_sharing_ref:
+            if collab not in TestFlowReference.all_ref_error_dict:
+                TestFlowReference.all_ref_error_dict[collab] = matched_ref_dict.get(
+                    collab
+                )
+
+    if not reference_flag:
+        log.info("Pass : Reference test passed for collaborators.")
+
+
+def validate_agg_attr_ref(agg_attrs, agg_obj):
+    """
+    Verifies aggregator attributes are retained after
+    collaborator execution
+    """
+    attr_flag = False
+    for attr in agg_attrs:
+        if TestFlowReference.agg_attr_dict.get(attr) == id(getattr(agg_obj, attr)):
+            attr_flag = True
+    if not attr_flag:
+        log.error(
+            "...Aggregator references are not intact after coming out of "
+            + "collaborators."
+        )
+    else:
+        log.info(
+            "Pass : Aggregator references are intact after coming out of "
+            + "collaborators."
+        )
+
+
+def validate_agg_collab_references(all_collborators, agg_obj, agg_attrs):
+    """
+    Iterate attributes of aggregator and collborator to capture the mismatched references.
+    """
+
+    mis_matched_ref = {}
+    for collab in all_collborators:
+        mis_matched_ref[collab.input] = []
+
+    attr_ref_flag = False
+    for attr in agg_attrs:
+        agg_attr_id = id(getattr(agg_obj, attr))
+        for collab in all_collborators:
+            collab_attr_id = id(getattr(collab, attr))
+            if agg_attr_id is collab_attr_id:
+                attr_ref_flag = True
+                mis_matched_ref.get(collab).append(attr)
+
+    if attr_ref_flag:
+        log.error(
+            "...Aggregator references are shared between collaborators."
+        )
+    else:
+        log.info(
+            "Pass : Reference test passed for aggregator."
+        )
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator = Aggregator()
+
+    # Setup collaborators private attributes via callable function
+    collaborator_names = ["Portland", "Seattle", "Chandler", "Bangalore"]
+
+    def callable_to_initialize_collaborator_private_attributes(index):
+        return {"index": index + 1}
+
+    collaborators = []
+    for idx, collaborator_name in enumerate(collaborator_names):
+        collaborators.append(
+            Collaborator(
+                name=collaborator_name,
+                private_attributes_callable=callable_to_initialize_collaborator_private_attributes,
+                index=idx,
+            )
+        )
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator,
+        collaborators=collaborators,
+    )
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "ray":
+            local_runtime = LocalRuntime(
+                aggregator=aggregator, collaborators=collaborators, backend="ray"
+            )
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    testflow = TestFlowReference(checkpoint=True)
+    testflow.runtime = local_runtime
+
+    for i in range(2):
+        log.info(f"Starting round {i}...")
+        testflow.run()

--- a/tests/end_to_end/workflow/reference_with_exclude_flow.py
+++ b/tests/end_to_end/workflow/reference_with_exclude_flow.py
@@ -1,0 +1,254 @@
+import logging
+
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+import sys
+import torch.nn as nn
+import torch.optim as optim
+import inspect
+from types import MethodType
+
+
+MIN_COLLECTION_COUNT = 2
+
+log = logging.getLogger(__name__)
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.linear1 = nn.Linear(60, 100)
+        self.linear2 = nn.Linear(100, 10)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.linear2(x)
+        return x
+
+
+class TestFlowReferenceWithExclude(FLSpec):
+
+    """
+    Testflow to validate references of collabartor attributes in Federated Flow with exclude.
+
+    """
+
+    step_one_collab_attrs = []
+    step_two_collab_attrs = []
+    all_ref_error_dict = {}
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+
+        """
+        self.agg_agg_attr_dict = {key: key for key in range(5)}
+        log.info("Testing FederatedFlow - Starting Test for validating references")
+        self.next(self.test_create_agg_attr, exclude=["agg_agg_attr_dict"])
+
+    @aggregator
+    def test_create_agg_attr(self):
+        """
+        Create different types of objects
+        """
+
+        self.agg_attr_list = [1, 2, 5, 6, 7, 8]
+        self.agg_attr_dict = {key: key for key in range(5)}
+        self.agg_attr_model = Net()
+        self.agg_attr_optimizer = optim.SGD(
+            self.agg_attr_model.parameters(), lr=1e-3, momentum=1e-2
+        )
+        self.collaborators = self.runtime.collaborators
+
+        self.next(
+            self.test_create_collab_attr,
+            foreach="collaborators",
+            exclude=["agg_attr_list"],
+        )
+
+    @collaborator
+    def test_create_collab_attr(self):
+        """
+        Create different types of objects
+        """
+        self.collab_attr_list_one = [1, 2, 3, 5, 6, 8]
+        self.collab_attr_dict_one = {key: key for key in range(5)}
+
+        TestFlowReferenceWithExclude.step_one_collab_attrs.append(self)
+
+        if (
+            len(TestFlowReferenceWithExclude.step_one_collab_attrs)
+            >= MIN_COLLECTION_COUNT
+        ):
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list,
+                TestFlowReferenceWithExclude.step_one_collab_attrs,
+            )
+            validate_references(matched_ref_dict)
+
+        self.next(self.test_create_more_collab_attr, exclude=["collab_attr_dict_one"])
+
+    @collaborator
+    def test_create_more_collab_attr(self):
+        """
+        Create different types of objects
+        """
+        self.collab_attr_list_two = [1, 2, 3, 5, 6, 8]
+        self.collab_attr_dict_two = {key: key for key in range(5)}
+
+        TestFlowReferenceWithExclude.step_two_collab_attrs.append(self)
+
+        if (
+            len(TestFlowReferenceWithExclude.step_two_collab_attrs)
+            >= MIN_COLLECTION_COUNT
+        ):
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list,
+                TestFlowReferenceWithExclude.step_two_collab_attrs,
+            )
+            validate_references(matched_ref_dict)
+
+        self.next(self.join, exclude=["collab_attr_dict_two"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Iterate over the references of collaborator attributes
+        validate uniqueness of attributes and raise assertion
+        """
+
+        all_attr_list = filter_attrs(inspect.getmembers(inputs[0]))
+
+        matched_ref_dict = find_matched_references(all_attr_list, inputs)
+        validate_references(matched_ref_dict)
+
+        all_shared_attr = ""
+        log.info("Reference with exclude keyword test summary:")
+
+        for val in TestFlowReferenceWithExclude.all_ref_error_dict.values():
+            all_shared_attr = all_shared_attr + ",".join(val)
+
+        if all_shared_attr:
+            log.error(f"Test case failed for {all_shared_attr}")
+        else:
+            log.info("Test case passed for all the attributes.")
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        log.info("Testing FederatedFlow - Ending test for validatng the references.")
+
+        if TestFlowReferenceWithExclude.all_ref_error_dict:
+            raise (
+                AssertionError(
+                    "Test case failed"
+                )
+            )
+
+        TestFlowReferenceWithExclude.step_one_collab_attrs = []
+        TestFlowReferenceWithExclude.step_two_collab_attrs = []
+        TestFlowReferenceWithExclude.all_ref_error_dict = {}
+
+
+def filter_attrs(attr_list):
+    valid_attrs = []
+    reserved_words = ["next", "runtime", "execute_next"]
+    for attr in attr_list:
+        if (
+            not attr[0].startswith("_")
+            and attr[0] not in reserved_words
+            and not hasattr(TestFlowReferenceWithExclude, attr[0])
+        ):
+            if not isinstance(attr[1], MethodType):
+                valid_attrs.append(attr[0])
+    return valid_attrs
+
+
+def find_matched_references(collab_attr_list, all_collaborators):
+    """
+    Iterate attributes of collborator and capture the duplicate reference
+    return: dict: {
+                    'Portland': ['failed attributes'], 'Seattle': [],
+                  }
+    """
+    matched_ref_dict = {}
+    for i in range(len(all_collaborators)):
+        matched_ref_dict[all_collaborators[i].input] = []
+
+    # For each attribute in the collaborator attribute list, check if any of the collaborator
+    # attributes are shared with another collaborator
+    for attr_name in collab_attr_list:
+        for i, curr_collab in enumerate(all_collaborators):
+            # Compare the current collaborator with the collaborator(s) that come(s) after it.
+            for next_collab in all_collaborators[i + 1:]:
+                # Check if both collaborators have the current attribute
+                if hasattr(curr_collab, attr_name) and hasattr(next_collab, attr_name):
+                    # Check if both collaborators are sharing same reference
+                    if getattr(curr_collab, attr_name) is getattr(
+                        next_collab, attr_name
+                    ):
+                        matched_ref_dict[curr_collab.input].append(attr_name)
+                        log.error(
+                            f"Reference test failed - {curr_collab.input} sharing same "
+                            + f"{attr_name} reference with {next_collab.input}"
+                        )
+
+    return matched_ref_dict
+
+
+def validate_references(matched_ref_dict):
+    """
+    Iterate reference list and raise assertion for conflicts
+    """
+    collborators_sharing_ref = []
+    reference_flag = False
+
+    for collab, val in matched_ref_dict.items():
+        if val:
+            collborators_sharing_ref.append(collab)
+            reference_flag = True
+    if collborators_sharing_ref:
+        for collab in collborators_sharing_ref:
+            if collab not in TestFlowReferenceWithExclude.all_ref_error_dict:
+                TestFlowReferenceWithExclude.all_ref_error_dict[
+                    collab
+                ] = matched_ref_dict.get(collab)
+
+    if not reference_flag:
+        log.info("Pass : Reference test passed")
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator = Aggregator()
+
+    # Setup collaborators
+    collaborator_names = ["Portland", "Seattle", "Chandler", "Bangalore"]
+    collaborators = []
+    for idx, collaborator_name in enumerate(collaborator_names):
+        collaborators.append(Collaborator(name=collaborator_name))
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator,
+        collaborators=collaborators,
+    )
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "ray":
+            local_runtime = LocalRuntime(
+                aggregator=aggregator, collaborators=collaborators, backend="ray"
+            )
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    testflow = TestFlowReferenceWithExclude(checkpoint=True)
+    testflow.runtime = local_runtime
+
+    for i in range(5):
+        log.info(f"Starting round {i}...")
+        testflow.run()

--- a/tests/end_to_end/workflow/reference_with_include_flow.py
+++ b/tests/end_to_end/workflow/reference_with_include_flow.py
@@ -1,0 +1,251 @@
+# Copyright (C) 2020-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.workflow.runtime import LocalRuntime
+from openfl.experimental.workflow.placement import aggregator, collaborator
+
+import sys
+import torch.nn as nn
+import torch.optim as optim
+import inspect
+from types import MethodType
+
+MIN_COLLECTION_COUNT = 2
+
+log = logging.getLogger(__name__)
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.linear1 = nn.Linear(60, 100)
+        self.linear2 = nn.Linear(100, 10)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.linear2(x)
+        return x
+
+
+class TestFlowReferenceWithInclude(FLSpec):
+
+    """
+    Testflow to validate references of collabartor attributes in Federated Flow with include.
+
+    """
+
+    step_one_collab_attrs = []
+    step_two_collab_attrs = []
+    all_ref_error_dict = {}
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+
+        """
+        self.agg_agg_attr_dict = {key: key for key in range(5)}
+        log.info("Testing FederatedFlow - Starting Test for validating references")
+        self.next(self.test_create_agg_attr, include=["agg_agg_attr_dict"])
+
+    @aggregator
+    def test_create_agg_attr(self):
+        """
+        Create different types of objects
+        """
+
+        self.agg_attr_list = [1, 2, 5, 6, 7, 8]
+        self.agg_attr_dict = {key: key for key in range(5)}
+
+        self.agg_attr_model = Net()
+        self.agg_attr_optimizer = optim.SGD(
+            self.agg_attr_model.parameters(), lr=1e-3, momentum=1e-2
+        )
+        self.collaborators = self.runtime.collaborators
+        self.next(
+            self.test_create_collab_attr,
+            foreach="collaborators",
+            include=["collaborators", "agg_attr_list"],
+        )
+
+    @collaborator
+    def test_create_collab_attr(self):
+        """
+        Modify the attirbutes of aggregator to validate the references.
+        Create different types of objects.
+        """
+
+        self.collab_attr_list_one = [1, 2, 5, 6, 7, 8]
+        self.collab_attr_dict_one = {key: key for key in range(5)}
+
+        # append self attributes of collaborators
+        TestFlowReferenceWithInclude.step_one_collab_attrs.append(self)
+
+        if (
+            len(TestFlowReferenceWithInclude.step_one_collab_attrs)
+            >= MIN_COLLECTION_COUNT
+        ):
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list,
+                TestFlowReferenceWithInclude.step_one_collab_attrs,
+            )
+            validate_references(matched_ref_dict)
+
+        self.next(self.test_create_more_collab_attr, include=["collab_attr_dict_one"])
+
+    @collaborator
+    def test_create_more_collab_attr(self):
+        """
+        Create different types of objects.
+        """
+
+        self.collab_attr_list_two = [1, 2, 3, 5, 6, 8]
+        self.collab_attr_dict_two = {key: key for key in range(5)}
+
+        TestFlowReferenceWithInclude.step_two_collab_attrs.append(self)
+
+        if (
+            len(TestFlowReferenceWithInclude.step_two_collab_attrs)
+            >= MIN_COLLECTION_COUNT
+        ):
+            collab_attr_list = filter_attrs(inspect.getmembers(self))
+            matched_ref_dict = find_matched_references(
+                collab_attr_list,
+                TestFlowReferenceWithInclude.step_two_collab_attrs,
+            )
+            validate_references(matched_ref_dict)
+
+        self.next(self.join, include=["collab_attr_dict_two"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Iterate over the references of collaborator attributes
+        validate uniqueness of attributes and raise assertion
+        """
+
+        all_attr_list = filter_attrs(inspect.getmembers(inputs[0]))
+
+        matched_ref_dict = find_matched_references(all_attr_list, inputs)
+        validate_references(matched_ref_dict)
+        all_shared_attr = ""
+        log.info("Reference test summary:")
+        for val in TestFlowReferenceWithInclude.all_ref_error_dict.values():
+            all_shared_attr = all_shared_attr + ",".join(val)
+        if all_shared_attr:
+            log.error(f"...Test case failed for {all_shared_attr}")
+        else:
+            log.info("...Test case passed for all the attributes.")
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        log.info("Testing FederatedFlow - Ending test for validatng the references.")
+        if TestFlowReferenceWithInclude.all_ref_error_dict:
+            raise (
+                AssertionError(
+                    "\n ...Test case failed ..."
+                )
+            )
+
+        TestFlowReferenceWithInclude.step_one_collab_attrs = []
+        TestFlowReferenceWithInclude.step_two_collab_attrs = []
+        TestFlowReferenceWithInclude.all_ref_error_dict = {}
+
+
+def filter_attrs(attr_list):
+    valid_attrs = []
+    reserved_words = ["next", "runtime", "execute_next"]
+    for attr in attr_list:
+        if (
+            not attr[0].startswith("_")
+            and attr[0] not in reserved_words
+            and not hasattr(TestFlowReferenceWithInclude, attr[0])
+        ):
+            if not isinstance(attr[1], MethodType):
+                valid_attrs.append(attr[0])
+    return valid_attrs
+
+
+def find_matched_references(collab_attr_list, all_collaborators):
+    """
+    Iterate attributes of collborator and capture the duplicate reference
+    return: dict: {
+                    'Portland': ['failed attributes'], 'Seattle': [],
+                  }
+    """
+    matched_ref_dict = {}
+    for i in range(len(all_collaborators)):
+        matched_ref_dict[all_collaborators[i].input] = []
+
+    # For each attribute in the collaborator attribute list, check if any of the collaborator
+    # attributes are shared with another collaborator
+    for attr_name in collab_attr_list:
+        for i, curr_collab in enumerate(all_collaborators):
+            # Compare the current collaborator with the collaborator(s) that come(s) after it.
+            for next_collab in all_collaborators[i + 1:]:
+                # Check if both collaborators have the current attribute
+                if hasattr(curr_collab, attr_name) and hasattr(next_collab, attr_name):
+                    # Check if both collaborators are sharing same reference
+                    if getattr(curr_collab, attr_name) is getattr(
+                        next_collab, attr_name
+                    ):
+                        matched_ref_dict[curr_collab.input].append(attr_name)
+                        log.error(f"... Reference test failed - {curr_collab.input} sharing same {attr_name} reference with {next_collab.input}")
+
+    return matched_ref_dict
+
+
+def validate_references(matched_ref_dict):
+    """
+    Iterate reference list and raise assertion for conflicts
+    """
+    collborators_sharing_ref = []
+    reference_flag = False
+
+    for collab, val in matched_ref_dict.items():
+        if val:
+            collborators_sharing_ref.append(collab)
+            reference_flag = True
+    if collborators_sharing_ref:
+        for collab in collborators_sharing_ref:
+            if collab not in TestFlowReferenceWithInclude.all_ref_error_dict:
+                TestFlowReferenceWithInclude.all_ref_error_dict[
+                    collab
+                ] = matched_ref_dict.get(collab)
+
+    if not reference_flag:
+        log.info("Pass : Reference test passed")
+
+
+if __name__ == "__main__":
+    # Setup participants
+    aggregator = Aggregator()
+
+    # Setup collaborators
+    collaborator_names = ["Portland", "Seattle", "Chandler", "Bangalore"]
+    collaborators = []
+    for idx, collaborator_name in enumerate(collaborator_names):
+        collaborators.append(Collaborator(name=collaborator_name))
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator,
+        collaborators=collaborators,
+    )
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "ray":
+            local_runtime = LocalRuntime(
+                aggregator=aggregator, collaborators=collaborators, backend="ray"
+            )
+
+    log.info(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    testflow = TestFlowReferenceWithInclude(checkpoint=True)
+    testflow.runtime = local_runtime
+
+    for i in range(5):
+        log.info(f"Starting round {i}...")
+        testflow.run()


### PR DESCRIPTION
Rewrite tests in `tests/github/experimental/workflow/LocalRuntime` to pytest format and move them to `tests/end_to_end/test_suites/wf_local_func_tests.py`.

* Add new test functions for `testflow_datastore_cli`, `testflow_include_exclude`, `testflow_include`, `testflow_reference_with_exclude`, and `testflow_reference_with_include` in `tests/end_to_end/test_suites/wf_local_func_tests.py`.
* Add `tests/end_to_end/workflow/datastore_cli_flow.py` with the content of `tests/github/experimental/workflow/LocalRuntime/testflow_datastore_cli.py`, import logging, and remove bcolors class usage.
* Add `tests/end_to_end/workflow/include_exclude_flow.py` with the content of `tests/github/experimental/workflow/LocalRuntime/testflow_include_exclude.py`, import logging, and remove bcolors class usage.
* Add `tests/end_to_end/workflow/include_flow.py` with the content of `tests/github/experimental/workflow/LocalRuntime/testflow_include.py`, import logging, and remove bcolors class usage.
* Add `tests/end_to_end/workflow/reference_with_exclude_flow.py` with the content of `tests/github/experimental/workflow/LocalRuntime/testflow_reference_with_exclude.py`, import logging, and remove bcolors class usage.
* Add `tests/end_to_end/workflow/reference_with_include_flow.py` with the content of `tests/github/experimental/workflow/LocalRuntime/testflow_reference_with_include.py`, import logging, and remove bcolors class usage.
* Delete `tests/github/experimental/workflow/LocalRuntime/testflow_datastore_cli.py`, `tests/github/experimental/workflow/LocalRuntime/testflow_include_exclude.py`, `tests/github/experimental/workflow/LocalRuntime/testflow_include.py`, `tests/github/experimental/workflow/LocalRuntime/testflow_reference_with_exclude.py`, `tests/github/experimental/workflow/LocalRuntime/testflow_reference_with_include.py`, and `tests/github/experimental/workflow/LocalRuntime/testflow_reference.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/payalcha/openfl/pull/6?shareId=4e444196-f339-4fe9-95a1-874a75cc099c).