### PR TITLE
Add copyright message to workflow files

### DIFF
--- a/tests/end_to_end/workflow/exclude_flow.py
+++ b/tests/end_to_end/workflow/exclude_flow.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 from openfl.experimental.workflow.interface import FLSpec

--- a/tests/end_to_end/workflow/include_exclude_flow.py
+++ b/tests/end_to_end/workflow/include_exclude_flow.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (C) 2020-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/end_to_end/workflow/include_flow.py
+++ b/tests/end_to_end/workflow/include_flow.py
@@ -1,3 +1,5 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 from openfl.experimental.workflow.interface import FLSpec
 from openfl.experimental.workflow.placement import aggregator, collaborator

--- a/tests/end_to_end/workflow/internal_loop.py
+++ b/tests/end_to_end/workflow/internal_loop.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from openfl.experimental.workflow.interface.fl_spec import FLSpec
 from openfl.experimental.workflow.interface.participants import Aggregator, Collaborator

--- a/tests/end_to_end/workflow/private_attr_both.py
+++ b/tests/end_to_end/workflow/private_attr_both.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 pass
 from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator

--- a/tests/end_to_end/workflow/private_attr_wo_callable.py
+++ b/tests/end_to_end/workflow/private_attr_wo_callable.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from openfl.experimental.workflow.interface import FLSpec, Aggregator, Collaborator
 from openfl.experimental.workflow.placement import aggregator, collaborator

--- a/tests/end_to_end/workflow/private_attributes_flow.py
+++ b/tests/end_to_end/workflow/private_attributes_flow.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 pass
 import numpy as np
 import logging

--- a/tests/end_to_end/workflow/reference_exclude.py
+++ b/tests/end_to_end/workflow/reference_exclude.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Intel Corporation
+# Copyright 2020-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from openfl.experimental.workflow.interface import FLSpec
@@ -171,7 +171,7 @@ def find_matched_references(collab_attr_list, all_collaborators):
     for attr_name in collab_attr_list:
         for i, curr_collab in enumerate(all_collaborators):
             # Compare the current collaborator with the collaborator(s) that come(s) after it.
-            for next_collab in all_collaborators[i + 1:]:
+            for next_collab in all_collaborators i + 1:]:
                 # Check if both collaborators have the current attribute
                 if hasattr(curr_collab, attr_name) and hasattr(next_collab, attr_name):
                     # Check if both collaborators are sharing same reference

--- a/tests/end_to_end/workflow/reference_flow.py
+++ b/tests/end_to_end/workflow/reference_flow.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Intel Corporation
+# Copyright 2020-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from openfl.experimental.workflow.interface import FLSpec

--- a/tests/end_to_end/workflow/reference_include_flow.py
+++ b/tests/end_to_end/workflow/reference_include_flow.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 pass
 import torch.nn as nn
 import torch.optim as optim
@@ -122,7 +125,7 @@ def filter_attrs(attr_list):
     for attr in attr_list:
         if (
             not attr[0].startswith("_")
-            and attr[0] not in reserved_words
+            and attr[0] not in reserved words
             and not hasattr(TestFlowReferenceWithInclude, attr[0])
         ):
             if not isinstance(attr[1], MethodType):

--- a/tests/end_to_end/workflow/subset_flow.py
+++ b/tests/end_to_end/workflow/subset_flow.py
@@ -1,3 +1,6 @@
+# Copyright 2020-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import random
 from openfl.experimental.workflow.interface.fl_spec import FLSpec


### PR DESCRIPTION
Add copyright message to the top of each file in the "tests/end_to_end/workflow/" folder.

* Add the copyright message to `exclude_flow.py`
* Add the copyright message to `include_exclude_flow.py`
* Add the copyright message to `include_flow.py`
* Add the copyright message to `internal_loop.py`
* Add the copyright message to `private_attr_both.py`
* Add the copyright message to `private_attr_wo_callable.py`
* Add the copyright message to `private_attributes_flow.py`
* Add the copyright message to `reference_exclude.py`
* Add the copyright message to `reference_flow.py`
* Add the copyright message to `reference_include_flow.py`
* Add the copyright message to `subset_flow.py`

